### PR TITLE
Refactor distance units to use class-based strategy

### DIFF
--- a/repository/IngSoft2-Model/Board.class.st
+++ b/repository/IngSoft2-Model/Board.class.st
@@ -36,7 +36,7 @@ Board class >> of: anAmountOfCells length: parsecLength andWormholeAt: positions
 { #category : 'initialize' }
 Board class >> of: anAmountOfCells length: parsecLength lengthLightYears: lightYears andWormholeAt: positions [
     (parsecLength notNil and: [ lightYears notNil ]) ifTrue: [
-        (parsecLength = (lightYears / 3)) ifFalse: [
+        ((Distance parsecs: parsecLength) asLightYears = lightYears) ifFalse: [
             self error: 'Length mismatch between parsecs and light years'.
         ].
     ].
@@ -52,7 +52,7 @@ Board class >> of: anAmountOfCells lengthLightYears: lightYears andWormholeAt: p
 
     ^ self
         of: anAmountOfCells
-        length: (lightYears / 3)
+        length: (Distance lightYears: lightYears) asParsecs
         andWormholeAt: positions.
 ]
 
@@ -202,8 +202,7 @@ Board >> stepsFromDistance: aDistance [
 { #category : 'initialize' }
 Board >> stepsFromLightYears: someLightYears [
     "Convert a distance expressed in light years to board steps"
-
-    ^ self stepsFromParsecs: (someLightYears / 3)
+    ^ self stepsFromParsecs: (Distance lightYears: someLightYears) asParsecs
 ]
 
 { #category : 'initialize' }

--- a/repository/IngSoft2-Model/Distance.class.st
+++ b/repository/IngSoft2-Model/Distance.class.st
@@ -1,40 +1,38 @@
 Class {
-	#name : 'Distance',
-	#superclass : 'Object',
-	#instVars : [
-		'value',
-		'unit'
-	],
-	#category : 'IngSoft2-Model',
-	#package : 'IngSoft2-Model'
+    #name : 'Distance',
+    #superclass : 'Object',
+    #instVars : [
+        'value',
+        'unit'
+    ],
+    #category : 'IngSoft2-Model',
+    #package : 'IngSoft2-Model'
 }
 
 { #category : 'instance creation' }
 Distance class >> lightYears: aNumber [
-    ^ self new initializeWith: aNumber unit: #lightYears
+    ^ self new initializeWith: aNumber unit: LightYear new
 ]
 
 { #category : 'instance creation' }
 Distance class >> parsecs: aNumber [
-    ^ self new initializeWith: aNumber unit: #parsecs
+    ^ self new initializeWith: aNumber unit: Parsec new
 ]
 
 { #category : 'accessing' }
 Distance >> asLightYears [
-    unit = #lightYears ifTrue: [ ^ value ].
-    ^ value * 3
+    ^ unit asLightYears: value
 ]
 
 { #category : 'accessing' }
 Distance >> asParsecs [
-    unit = #parsecs ifTrue: [ ^ value ].
-    ^ value / 3
+    ^ unit asParsecs: value
 ]
 
 { #category : 'initialization' }
-Distance >> initializeWith: aNumber unit: aSymbol [
+Distance >> initializeWith: aNumber unit: aUnit [
     value := aNumber.
-    unit := aSymbol.
+    unit := aUnit.
     ^ self
 ]
 

--- a/repository/IngSoft2-Model/DistanceUnit.class.st
+++ b/repository/IngSoft2-Model/DistanceUnit.class.st
@@ -1,0 +1,16 @@
+Class {
+    #name : 'DistanceUnit',
+    #superclass : 'Object',
+    #category : 'IngSoft2-Model',
+    #package : 'IngSoft2-Model'
+}
+
+{ #category : 'conversions' }
+DistanceUnit >> asLightYears: aNumber [
+    self subclassResponsibility
+]
+
+{ #category : 'conversions' }
+DistanceUnit >> asParsecs: aNumber [
+    self subclassResponsibility
+]

--- a/repository/IngSoft2-Model/LightYear.class.st
+++ b/repository/IngSoft2-Model/LightYear.class.st
@@ -1,0 +1,16 @@
+Class {
+    #name : 'LightYear',
+    #superclass : 'DistanceUnit',
+    #category : 'IngSoft2-Model',
+    #package : 'IngSoft2-Model'
+}
+
+{ #category : 'conversions' }
+LightYear >> asLightYears: aNumber [
+    ^ aNumber
+]
+
+{ #category : 'conversions' }
+LightYear >> asParsecs: aNumber [
+    ^ aNumber / 3
+]

--- a/repository/IngSoft2-Model/Parsec.class.st
+++ b/repository/IngSoft2-Model/Parsec.class.st
@@ -1,0 +1,16 @@
+Class {
+    #name : 'Parsec',
+    #superclass : 'DistanceUnit',
+    #category : 'IngSoft2-Model',
+    #package : 'IngSoft2-Model'
+}
+
+{ #category : 'conversions' }
+Parsec >> asLightYears: aNumber [
+    ^ aNumber * 3
+]
+
+{ #category : 'conversions' }
+Parsec >> asParsecs: aNumber [
+    ^ aNumber
+]

--- a/repository/IngSoft2-Tests/DistanceTest.class.st
+++ b/repository/IngSoft2-Tests/DistanceTest.class.st
@@ -1,8 +1,8 @@
 Class {
-	#name : 'DistanceTest',
-	#superclass : 'TestCase',
-	#category : 'IngSoft2-Tests',
-	#package : 'IngSoft2-Tests'
+    #name : 'DistanceTest',
+    #superclass : 'TestCase',
+    #category : 'IngSoft2-Tests',
+    #package : 'IngSoft2-Tests'
 }
 
 { #category : 'tests - instance' }
@@ -36,9 +36,9 @@ DistanceTest >> testAsParsecsFromParsecsReturnsValue [
 { #category : 'tests - instance' }
 DistanceTest >> testInitializationSetsValueAndUnit [
     | distance |
-    distance := Distance new initializeWith: 7 unit: #parsecs.
+    distance := Distance new initializeWith: 7 unit: Parsec new.
     self assert: distance value equals: 7.
-    self assert: distance unit equals: #parsecs.
+    self assert: distance unit class equals: Parsec.
 ]
 
 { #category : 'tests - instance' }
@@ -46,7 +46,7 @@ DistanceTest >> testLightYearsClassMethodCreatesLightYearsDistance [
     | distance |
     distance := Distance lightYears: 3.
     self assert: distance value equals: 3.
-    self assert: distance unit equals: #lightYears.
+    self assert: distance unit class equals: LightYear.
 ]
 
 { #category : 'tests - instance' }
@@ -54,5 +54,5 @@ DistanceTest >> testParsecsClassMethodCreatesParsecsDistance [
     | distance |
     distance := Distance parsecs: 8.
     self assert: distance value equals: 8.
-    self assert: distance unit equals: #parsecs.
+    self assert: distance unit class equals: Parsec.
 ]


### PR DESCRIPTION
Replaces symbolic distance units with dedicated classes (DistanceUnit, LightYear, Parsec) to encapsulate conversion logic. Updates Board and Distance to use these classes for conversions, and adjusts tests accordingly. This improves extensibility and encapsulation of unit conversion behavior.