### PR TITLE
Refactor light year and parsec conversions to use constant

### DIFF
--- a/repository/IngSoft2-Model/LightYear.class.st
+++ b/repository/IngSoft2-Model/LightYear.class.st
@@ -12,5 +12,5 @@ LightYear >> asLightYears: aNumber [
 
 { #category : 'conversions' }
 LightYear >> asParsecs: aNumber [
-    ^ aNumber / 3
+    ^ aNumber / Parsec lightYearsPerParsec
 ]

--- a/repository/IngSoft2-Model/Parsec.class.st
+++ b/repository/IngSoft2-Model/Parsec.class.st
@@ -7,10 +7,15 @@ Class {
 
 { #category : 'conversions' }
 Parsec >> asLightYears: aNumber [
-    ^ aNumber * 3
+    ^ aNumber * Parsec lightYearsPerParsec
 ]
 
 { #category : 'conversions' }
 Parsec >> asParsecs: aNumber [
     ^ aNumber
+]
+
+{ #category : 'constants' }
+Parsec class >> lightYearsPerParsec [
+    ^ 3
 ]


### PR DESCRIPTION
Replaced hardcoded conversion factor (3) with Parsec class constant lightYearsPerParsec in LightYear and Parsec conversion methods. Added lightYearsPerParsec class method to Parsec for maintainability and clarity.