### PR TITLE
Refactor card drawing logic to use Board>>drawCard

### DIFF
--- a/repository/IngSoft2-Model/Board.class.st
+++ b/repository/IngSoft2-Model/Board.class.st
@@ -184,13 +184,20 @@ Board >> positionOf: aShip [
 
 { #category : 'initialize' }
 Board >> randomEffect [
-	| r |
+        | r |
     r := (1 to: 100) atRandom.
     r <= 10 ifTrue: [ ^ CardEffect new ].
     r <= 48 ifTrue: [ ^ NoEffect new ].
     r <= 74 ifTrue: [ ^ BlackHoleEffect new ].
-	^ HyperGravityEffect new.
+        ^ HyperGravityEffect new.
 
+]
+
+{ #category : 'deck' }
+Board >> drawCard [
+    "Return a random card from the deck"
+
+    ^ CardDeck randomCard
 ]
 
 { #category : 'spaceships' }

--- a/repository/IngSoft2-Model/CardEffect.class.st
+++ b/repository/IngSoft2-Model/CardEffect.class.st
@@ -7,5 +7,5 @@ Class {
 
 { #category : 'operations' }
 CardEffect >> applyEffectTo: aSpaceship inBoard: aBoard [
-	aSpaceship addCard: CardDeck randomCard.
+        aSpaceship addCard: (aBoard drawCard).
 ]

--- a/repository/IngSoft2-Model/Game.class.st
+++ b/repository/IngSoft2-Model/Game.class.st
@@ -185,7 +185,7 @@ Game >> initializeWithShips: someShips board: aBoard dice: someDices laps: aNumb
         shipStatuses := Dictionary new.
        spaceShips do: [ :ship |
                 shipStatuses at: ship put: (ShipStatus for: ship position: 0 laps: 0 penalized: false).
-                2 timesRepeat: [ ship addCard: CardDeck randomCard ] ].
+                2 timesRepeat: [ ship addCard: (board drawCard) ] ].
         state := GameInProgress new.
 	
 	lastSteps := 0.


### PR DESCRIPTION
Introduced a new drawCard method in Board to centralize card drawing logic. Updated CardEffect and Game classes to use Board's drawCard instead of directly accessing CardDeck, improving encapsulation and maintainability.