### PR TITLE
Fix HyperGravityEffect to move ship backwards by one

### DIFF
--- a/repository/IngSoft2-Model/HyperGravityEffect.class.st
+++ b/repository/IngSoft2-Model/HyperGravityEffect.class.st
@@ -15,7 +15,10 @@ HyperGravityEffect >> allowsEntryWithRoll: aNumber [
 
 { #category : 'operations' }
 HyperGravityEffect >> applyEffectTo: aSpaceship inBoard: aBoard [
-        ^ self.
+    aBoard
+        ifNil: [ aSpaceship moveBack: 1 ]
+        ifNotNil: [ aBoard moveShip: aSpaceship backward: 1 ].
+    ^ aSpaceship.
 ]
 
 { #category : 'initialization' }

--- a/repository/IngSoft2-Tests/HyperGravityEffectTest.class.st
+++ b/repository/IngSoft2-Tests/HyperGravityEffectTest.class.st
@@ -29,7 +29,7 @@ HyperGravityEffectTest >> testAllowsEntryWithRollTrueWhenEnough [
 ]
 
 { #category : 'tests' }
-HyperGravityEffectTest >> testApplyToDoesNothing [
+HyperGravityEffectTest >> testApplyToMovesShipBackwardsOneStep [
 
     | ship effect |
 
@@ -39,5 +39,5 @@ HyperGravityEffectTest >> testApplyToDoesNothing [
     effect := HyperGravityEffect new.
     effect applyTo: ship.
 
-    self assert: ship position equals: 5.
+    self assert: ship position equals: 4.
 ]


### PR DESCRIPTION
Updated the applyEffectTo:inBoard: method in HyperGravityEffect to move the spaceship back by one step, handling both nil and non-nil board cases. Adjusted the corresponding test to assert the correct new position after the effect is applied.