### PR TITLE
Handle Distance objects in Board length parameter

### DIFF
--- a/repository/IngSoft2-Model/Board.class.st
+++ b/repository/IngSoft2-Model/Board.class.st
@@ -29,7 +29,9 @@ Board class >> of: anAmountOfCells length: parsecLength andWormholeAt: positions
     self validateWormholes: positions.
     ^ self new
         initializeWithCells: anAmountOfCells
-        length: parsecLength
+        length: ((parsecLength isKindOf: Distance)
+            ifTrue: [ parsecLength asParsecs ]
+            ifFalse: [ parsecLength ])
         andWormholes: positions.
 ]
 

--- a/repository/IngSoft2-Tests/BoardTest.class.st
+++ b/repository/IngSoft2-Tests/BoardTest.class.st
@@ -140,6 +140,14 @@ BoardTest >> testBoardCreationWithParsecsAndLightYears [
 ]
 
 { #category : 'tests - instance' }
+BoardTest >> testBoardCreationWithDistanceParsecLength [
+    | board |
+    board := Board of: 10 length: (Distance parsecs: 12) andWormholeAt: #().
+
+    self assert: (board stepsFromParsecs: 3) equals: 3.
+]
+
+{ #category : 'tests - instance' }
 BoardTest >> testBoardInitializesCorrectNumberOfEffects [
 	| board |
 	board := Board of: 20 andWormholeAt: OrderedCollection new.


### PR DESCRIPTION
Updated Board class to convert Distance objects to parsecs when initializing with a length parameter. Added a test to verify board creation with a Distance object as the length.